### PR TITLE
Add string enum to gasOptions type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,7 +9,7 @@ export type APIError = {
 }
 
 export type Options = {
-    gasOptions?: string, // TODO: Use enum
+    gasOptions?: "FAST" | "STD" | "SLOW",
     slippage?: number,
     partnerId? :number
 }


### PR DESCRIPTION
Change `gasOptions` type from string to enum `"FAST" | "STD" | "SLOW"`.