### PR TITLE
Refactor duplicate function and renamed gas option type

### DIFF
--- a/src/types/TradeOptions.ts
+++ b/src/types/TradeOptions.ts
@@ -1,4 +1,4 @@
-import { Options } from "./Web3"
+import { GasOption } from "./Web3"
 
 type Trade = {
     routes: number[]
@@ -7,7 +7,7 @@ type Trade = {
     rate: string
 }
 
-type TradeOption = {
+export type TradeOption = {
     gasPrice: string
     gasLimit: number
     trade: Trade
@@ -27,9 +27,9 @@ export type Rate = {
     toAmount: string
     toSymbol : string
     gasOptions: {
-        "FAST": Options,
-        "STD": Options,
-        "SLOW": Options
+        "FAST": GasOption,
+        "STD": GasOption,
+        "SLOW": GasOption
     }
 }
 

--- a/src/types/Web3.ts
+++ b/src/types/Web3.ts
@@ -30,7 +30,7 @@
 //     from?: string,
 // ) => Promise<Web3Signature>;
 
-export interface Options {
+export interface GasOption {
     readonly gasLimit: string;
     readonly gasPrice: any;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 
-import { TradeOptions, Rate } from "./TradeOptions"
+import { GasOption } from './Web3'
+import { TradeOption, TradeOptions, Rate } from "./TradeOptions"
 import { Configuration, Network } from "./Configuration"
 
 
@@ -15,6 +16,8 @@ export type Options = {
 }
 
 export {
+    GasOption,
+    TradeOption,
     TradeOptions,
     Configuration,
     Network,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 import { TOKEN_ADDRESSES, TOKEN_DECIMALS } from "../constants"
-import { Options } from "../types/Web3"
+import { GasOption } from "../types/Web3"
 import { Rate } from "../types"
 
 export const resolveContractAddress = (symbol: string): String => {
@@ -12,7 +12,7 @@ export const resolveTokenDecimals = (symbol: string): Number => {
     return TOKEN_DECIMALS[symbol] ? TOKEN_DECIMALS[symbol] : 18
 }
 
-export const constructGasOptions = (option: string, rate: Rate): any => {
+export const constructGasOptions = (option: string, rate: Rate): GasOption => {
     switch (option) {
         case "FAST":
             return rate.gasOptions["FAST"]
@@ -23,6 +23,6 @@ export const constructGasOptions = (option: string, rate: Rate): any => {
     }
 }
 
-export const defaultGasOptions = (rate: Rate): any => {
+export const defaultGasOptions = (rate: Rate): GasOption => {
     return rate.gasOptions["FAST"]
 }


### PR DESCRIPTION
`reduceOption` function is declared in both `getRate` and `getRateAmountOut` function, so it would be better if changed to a class method.

```ts
const reduceOption = (option: any) => {
	return {
		gasLimit: option.gasLimit,
		gasPrice: `${this.web3.utils.toWei(option.gasPrice, "gwei")}`
	}
}
```

Change to a private class method.

```ts
private getGasOption(option: TradeOption): GasOption {
	return {
		gasLimit: `${option.gasLimit}`,
		gasPrice: `${this.web3.utils.toWei(option.gasPrice, "gwei")}`
	}
}
```

And I also changed the type name from `Options` to `GasOption` in `types/Web3.ts` for better understanding, no idea this is good or not. 